### PR TITLE
Add Indie Hacker Toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,11 @@
 
 
 ## 模板
-- [Tailwind UI](https://tailwindui.com/templates): 提供多种基于Tailwind CSS的响应式模板，适用于各种应用场景。
+- [Indie Hacker Toolkit](https://github.com/Wittlesus/indie-hacker-toolkit): 为独立开发者提供的5个实用规划模板，包括产品发布清单、定价计算器、竞争对手分析、用户画像和指标仪表板。付费产品，$19。
+- [Makerkit](https://makerkit.dev/): 提供多种基于Next.js的响应式模板，适用于各种应用场景。
 - [Shipfast](https://shipfa.st/): 提供多种基于Tailwind CSS的响应式模板，适用于各种应用场景。
 - [Supastarter](https://supastarter.com/): 提供多种基于Next.js的响应式模板，适用于各种应用场景。
-- [Makerkit](https://makerkit.dev/): 提供多种基于Next.js的响应式模板，适用于各种应用场景。
+- [Tailwind UI](https://tailwindui.com/templates): 提供多种基于Tailwind CSS的响应式模板，适用于各种应用场景。
 
 ## 开发工具
 - [VS Code](https://code.visualstudio.com/): 微软开发的免费、开源代码编辑器。支持多种编程语言、调试、Git集成等功能，拥有丰富的扩展生态系统。


### PR DESCRIPTION
Hi! I'd like to add **Indie Hacker Toolkit** to the templates section of this awesome list.

**What is it?**
Indie Hacker Toolkit is a collection of 5 practical planning templates designed specifically for solo founders and indie hackers. It includes:
- Product launch checklist
- Pricing calculator
- Competitor analysis template
- User persona template
- Metrics dashboard

**Why include it?**
This toolkit helps indie hackers with the planning and business side of product development, complementing the technical tools already listed in this repository. It's actively maintained and available at https://github.com/Wittlesus/indie-hacker-toolkit.

**Where I added it:**
I placed it alphabetically in the "模板" (Templates) section, which seemed like the most appropriate category for planning templates.

Thank you for maintaining this valuable resource for the indie hacker community!