### PR TITLE
Add PageGuard - free website health scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@
 - [Redirect Checker](https://redirect-checker.autocompany.workers.dev): 开源HTTP重定向链分析工具，检测重定向循环，支持多种User-Agent。完全免费。
 - [SSL Certificate Monitor](https://ssl-certificate-monitor.autocompany.workers.dev): 开源SSL/TLS证书到期监控工具，帮助独立开发者确保证书不会过期。完全免费。
 - [DNS Propagation Checker](https://dns-propagation-checker.autocompany.workers.dev): 开源DNS传播检查工具，全球多节点查询DNS记录传播状态。完全免费。
+- [PageGuard](https://pageguard.org): 免费网站健康扫描工具，一键检测SEO、性能、无障碍性和最佳实践，提供AI分析报告和REST API，无需注册。
 
 
 


### PR DESCRIPTION
## What's this?

Adding [PageGuard](https://pageguard.org) to the SEO section.

**PageGuard** is a free, open-source website health scanner that checks:
- SEO — meta tags, structured data, crawlability
- Performance — Core Web Vitals, load speed
- Accessibility — WCAG compliance checks
- Best Practices — security headers, HTTPS, etc.
- AI-generated action plan reports
- REST API (no login required)

## Why it fits

It belongs alongside the other free developer tools in the SEO section, providing comprehensive website auditing in one place.

**GitHub**: https://github.com/sleepyxpad-jpg/pageguard