### PR TITLE
Add LastSaaS

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@
 - [Shipfast](https://shipfa.st/): 提供多种基于Tailwind CSS的响应式模板，适用于各种应用场景。
 - [Supastarter](https://supastarter.com/): 提供多种基于Next.js的响应式模板，适用于各种应用场景。
 - [Tailwind UI](https://tailwindui.com/templates): 提供多种基于Tailwind CSS的响应式模板，适用于各种应用场景。
+- [LastSaaS](https://github.com/jonradoff/lastsaas): 开源SaaS平台基础框架，提供多租户认证、Stripe支付集成、白标品牌定制和管理仪表板。基于Go + React + MongoDB构建，MIT许可证。免费开源。
 
 ## 开发工具
 - [VS Code](https://code.visualstudio.com/): 微软开发的免费、开源代码编辑器。支持多种编程语言、调试、Git集成等功能，拥有丰富的扩展生态系统。


### PR DESCRIPTION
## Summary
- Adds [LastSaaS](https://github.com/jonradoff/lastsaas) to the Templates (模板) section
- LastSaaS is an open-source SaaS platform foundation with multi-tenant auth, Stripe billing, white-label branding, and admin dashboard. Built with Go + React + MongoDB. MIT license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)