### PR TITLE
Add Waitlio to Product Launch and Promotion section

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@
 - [LinkedIn](https://www.linkedin.com/): 职业社交网络，适合B2B产品的推广和建立专业形象。
 - [ProductHunt Upcoming](https://www.producthunt.com/upcoming/): Product Hunt的预发布板块，可以在正式发布前积累兴趣。
 - [BetaList](https://betalist.com/): 专注于展示早期创业项目和产品的平台。
+- [Waitlio](https://waitlio.com/): 免费的等候名单管理工具，可在几秒钟内创建品牌化的预发布页面，收集邮箱订阅者，自动验证注册，并管理你的产品发布。提供免费计划，按需升级。
 - [v2ex](https://www.v2ex.com/): 中文技术社区，有专门的创造板块用于分享个人项目。
 - [少数派](https://sspai.com/): 面向中文用户的科技媒体，可以投稿介绍新产品。
 

--- a/README_en.md
+++ b/README_en.md
@@ -264,6 +264,7 @@ Website address [Awesome Indie Hacker Tools](https://awesomeindiehacker.tools) (
 - [LinkedIn](https://www.linkedin.com/): A professional social network suitable for B2B product promotion and building a professional image.
 - [ProductHunt Upcoming](https://www.producthunt.com/upcoming/): Product Hunt's pre-launch section where you can accumulate interest before official launch.
 - [BetaList](https://betalist.com/): A platform focused on showcasing early-stage startup projects and products.
+- [Waitlio](https://waitlio.com/): Free waitlist management tool to create branded pre-launch pages in seconds, collect email subscribers, verify signups automatically, and manage your product launch. Free plan included, upgrade as you grow.
 - [v2ex](https://www.v2ex.com/): A Chinese tech community with a dedicated section for sharing personal projects.
 - [少数派](https://sspai.com/): A tech media platform for Chinese users where you can submit articles introducing new products.
 

--- a/src/data/tools/product-launch.ts
+++ b/src/data/tools/product-launch.ts
@@ -88,6 +88,17 @@ export const productLaunchPlatforms = [
     },
   },
   {
+    title: "Waitlio",
+    category: "产品发布推广",
+    tags: ["等候名单", "预发布", "邮箱收集", "免费"],
+    slug: "waitlio",
+    description: "免费的等候名单管理工具，可在几秒钟内创建品牌化的预发布页面，收集邮箱订阅者，自动验证注册，并管理你的产品发布。提供免费计划，按需升级。",
+    site: {
+      name: "Waitlio",
+      url: "https://waitlio.com/",
+    },
+  },
+  {
     title: "v2ex",
     category: "产品发布推广",
     tags: ["中文社区", "技术讨论", "创造板块"],


### PR DESCRIPTION
## Summary

Adding [Waitlio](https://waitlio.com) to the Product Launch and Promotion section.

Waitlio is a free waitlist management tool for product launches. It lets indie hackers create branded pre-launch pages, collect and verify email subscribers, and manage their launch — no code required. Free plan included.

### Changes

- Added Waitlio to the Product Launch and Promotion section in `README.md` (Chinese)
- Added Waitlio to the Product Launch and Promotion section in `README_en.md` (English)
- Added Waitlio entry to `src/data/tools/product-launch.ts`