### PR TITLE
Add Beam — privacy-first web analytics for indie hackers (no cookies, free tier)

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@
 - [Kissmetrics](https://www.kissmetrics.io/): 专注于客户生命周期分析的平台，帮助优化用户获取和留存。仅提供付费计划。
 - [Plausible](https://plausible.io/): 轻量级、开源的网站分析工具，注重简洁和隐私。提供付费的托管服务，起价$9/月。
 - [Umami](https://umami.is/): 简单、快速、隐私友好的开源网站分析工具。可免费自托管，也提供付费的托管服务。
+- [Beam](https://beam-privacy.com/): 基于Cloudflare Workers的隐私优先网站分析工具。无Cookie，无需同意横幅，默认符合GDPR。提供免费版（1个站点，5万页面浏览量），付费计划起价$9/月。
 
 
 ## SEO

--- a/README_en.md
+++ b/README_en.md
@@ -280,6 +280,7 @@ Website address [Awesome Indie Hacker Tools](https://awesomeindiehacker.tools) (
 - [Kissmetrics](https://www.kissmetrics.io/): A platform focused on customer lifecycle analysis, helping optimize user acquisition and retention. Only offers paid plans.
 - [Plausible](https://plausible.io/): A lightweight, open-source website analytics tool focusing on simplicity and privacy. Offers paid hosting services starting at $9/month.
 - [Umami](https://umami.is/): A simple, fast, privacy-friendly open-source website analytics tool. Can be self-hosted for free, also offers paid hosting services.
+- [Beam](https://beam-privacy.com/): Privacy-first web analytics built on Cloudflare Workers. No cookies, no consent banners, GDPR-compliant by default. Free tier (1 site, 50K pageviews) and paid plans from $9/month.
 
 
 ## SEO

--- a/README_zh.md
+++ b/README_zh.md
@@ -278,6 +278,7 @@
 - [Kissmetrics](https://www.kissmetrics.io/): 专注于客户生命周期分析的平台，帮助优化用户获取和留存。仅提供付费计划。
 - [Plausible](https://plausible.io/): 轻量级、开源的网站分析工具，注重简洁和隐私。提供付费的托管服务，起价$9/月。
 - [Umami](https://umami.is/): 简单、快速、隐私友好的开源网站分析工具。可免费自托管，也提供付费的托管服务。
+- [Beam](https://beam-privacy.com/): 基于Cloudflare Workers的隐私优先网站分析工具。无Cookie，无需同意横幅，默认符合GDPR。提供免费版（1个站点，5万页面浏览量），付费计划起价$9/月。
 
 
 ## SEO


### PR DESCRIPTION
## What is Beam?

[Beam](https://beam-privacy.com) is a privacy-first web analytics platform built on Cloudflare Workers. It lets indie hackers track visitors, pageviews, and referrers without cookies, consent banners, or privacy-compromising tracking.

## Why it fits this list

Indie hackers building products often need analytics without the complexity (or privacy concerns) of Google Analytics. Beam is:

- **Simple to install** — one `<script>` tag in `<head>`
- **Free tier** — 1 site, 50,000 pageviews/month — sufficient for early-stage products
- **No cookies** — no consent banner needed, fully GDPR/CCPA-compliant
- **Privacy-preserving** — no IP storage, no cross-site tracking, no third-party data sharing
- **Fast** — edge-deployed globally on Cloudflare Workers (~1ms latency)
- **Affordable** — Pro plan at $9/month for unlimited sites, 500K pageviews

Beam belongs alongside Plausible and Umami as a lightweight, privacy-first Google Analytics alternative for builders who care about their users' privacy.

## Links

- Live product: https://beam-privacy.com
- GitHub (tracking script): https://github.com/scobb/beam.js
- Docs / integration guides: https://beam-privacy.com/for

This PR adds Beam to both `README_en.md` (English) and `README_zh.md` / `README.md` (Chinese) to keep both versions in sync.
