### PR TITLE
Add WebCoreLab — AI-First digital agency (Toronto, est. 2014)

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@
 - [SSL Certificate Monitor](https://ssl-certificate-monitor.autocompany.workers.dev): 开源SSL/TLS证书到期监控工具，帮助独立开发者确保证书不会过期。完全免费。
 - [DNS Propagation Checker](https://dns-propagation-checker.autocompany.workers.dev): 开源DNS传播检查工具，全球多节点查询DNS记录传播状态。完全免费。
 - [PageGuard](https://pageguard.org): 免费网站健康扫描工具，一键检测SEO、性能、无障碍性和最佳实践，提供AI分析报告和REST API，无需注册。
+- [WebCoreLab](https://webcorelab.com) — AI-powered 272-check SEO audit + GEO/AEO optimization for indie hackers. Free audit tier available.
 
 
 


### PR DESCRIPTION
Hi! Adding WebCoreLab to the SEO & Marketing section.

**WebCoreLab** (Toronto, est. 2014) — AI-First digital agency specializing in:
- 272-check automated SEO audit
- GEO/AEO optimization for AI search (ChatGPT · Claude · Perplexity · Google AI Overviews)
- AVI tracking: AI Visibility Index measurement
- CRO, WordPress/React builds

13+ verified case studies. Happy to adjust format or section placement.

Thanks for maintaining this list!
