### PR TITLE
Add AppLighter and RapidNative to Templates and Prototyping (EN + ZH)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@
 - [Framer](https://www.framer.com/): 一个基于Web的UI设计工具，支持多种框架，提供实时预览和协作。有免费计划，专业版起价$15/月。
 - [Webflow](https://webflow.com/): 一个基于Web的UI设计工具，支持多种框架，提供实时预览和协作。有免费计划，付费计划起价$14/月。
 - [Berrry](https://berrry.app): AI驱动的原型工具，将Twitter和Reddit内容转换为功能性Web应用原型
+- [RapidNative](https://rapidnative.com/): AI 原生移动应用构建器，将创意、草图或截图转换为可运行的 React Native 和 Expo 应用，生成可查看、编辑和扩展的生产级代码。免费增值（20 个免费额度）。
 
 
 
@@ -125,6 +126,7 @@
 - [Shipfast](https://shipfa.st/): 提供多种基于Tailwind CSS的响应式模板，适用于各种应用场景。
 - [Supastarter](https://supastarter.com/): 提供多种基于Next.js的响应式模板，适用于各种应用场景。
 - [Tailwind UI](https://tailwindui.com/templates): 提供多种基于Tailwind CSS的响应式模板，适用于各种应用场景。
+- [AppLighter](https://applighter.com/): 基于 React Native + Expo 的全栈应用模板，专为由 AI 编程代理（Cursor、Claude Code）扩展而设计，采用 NativeWind 和分层架构。付费，按模板一次性收费。
 
 ## 开发工具
 - [VS Code](https://code.visualstudio.com/): 微软开发的免费、开源代码编辑器。支持多种编程语言、调试、Git集成等功能，拥有丰富的扩展生态系统。

--- a/README_en.md
+++ b/README_en.md
@@ -63,6 +63,7 @@ Website address [Awesome Indie Hacker Tools](https://awesomeindiehacker.tools) (
 - [Sketch](https://www.sketch.com/): A Mac-based UI design tool that supports multiple frameworks, providing real-time preview and collaboration. Personal version $9/month, team version $20/month/editor.
 - [Framer](https://www.framer.com/): A web-based UI design tool that supports multiple frameworks, providing real-time preview and collaboration. Has a free plan, professional version starts at $15/month.
 - [Webflow](https://webflow.com/): A web-based UI design tool that supports multiple frameworks, providing real-time preview and collaboration. Has a free plan, paid plans start at $14/month.
+- [RapidNative](https://rapidnative.com/): An AI-native mobile app builder that turns ideas, sketches, or screenshots into working React Native and Expo apps. Generates production-ready code that can be viewed, edited, and extended. Freemium with 20 free credits.
 
 
 
@@ -125,6 +126,7 @@ Website address [Awesome Indie Hacker Tools](https://awesomeindiehacker.tools) (
 - [Supastarter](https://supastarter.com/): Offers various responsive templates based on Next.js, suitable for different application scenarios.
 - [Makerkit](https://makerkit.dev/): Offers various responsive templates based on Next.js, suitable for different application scenarios.
 - [Vibe Coding Starter Kit](https://vibecodingstarterkit.io/): AI-powered Next.js boilerplate for non-technical founders, featuring AI commands, pre-configured auth, payments, and rapid development tools.
+- [AppLighter](https://applighter.com/): Production-ready full-stack React Native + Expo app templates designed to be extended by AI coding agents (Cursor, Claude Code). Layered architecture, security posture, and designer-grade UI. Paid, one-time per template.
 
 ## Development Tools
 - [VS Code](https://code.visualstudio.com/): A free, open-source code editor developed by Microsoft. Supports multiple programming languages, debugging, Git integration, and other features, with a rich extension ecosystem.

--- a/README_zh.md
+++ b/README_zh.md
@@ -63,6 +63,7 @@
 - [Sketch](https://www.sketch.com/): 一个基于Mac的UI设计工具，支持多种框架，提供实时预览和协作。个人版$9/月，团队版$20/月/编辑者。
 - [Framer](https://www.framer.com/): 一个基于Web的UI设计工具，支持多种框架，提供实时预览和协作。有免费计划，专业版起价$15/月。
 - [Webflow](https://webflow.com/): 一个基于Web的UI设计工具，支持多种框架，提供实时预览和协作。有免费计划，付费计划起价$14/月。
+- [RapidNative](https://rapidnative.com/): AI 原生移动应用构建器，将创意、草图或截图转换为可运行的 React Native 和 Expo 应用，生成可查看、编辑和扩展的生产级代码。免费增值（20 个免费额度）。
 
 
 
@@ -123,6 +124,7 @@
 - [Shipfast](https://shipfa.st/): 提供多种基于Tailwind CSS的响应式模板，适用于各种应用场景。
 - [Supastarter](https://supastarter.com/): 提供多种基于Next.js的响应式模板，适用于各种应用场景。
 - [Makerkit](https://makerkit.dev/): 提供多种基于Next.js的响应式模板，适用于各种应用场景。
+- [AppLighter](https://applighter.com/): 基于 React Native + Expo 的全栈应用模板，专为由 AI 编程代理（Cursor、Claude Code）扩展而设计，采用 NativeWind 和分层架构。付费，按模板一次性收费。
 
 ## 开发工具
 - [VS Code](https://code.visualstudio.com/): 微软开发的免费、开源代码编辑器。支持多种编程语言、调试、Git集成等功能，拥有丰富的扩展生态系统。


### PR DESCRIPTION
## Adding AppLighter and RapidNative

Submitting two related tools relevant to the indie hacker / vibe-coding workflow. Entries added to all three README files (README.md, README_en.md, README_zh.md).

### [AppLighter](https://applighter.com/) → Templates / 模板
- **What:** Full-stack React Native + Expo app templates built for the AI agent era — layered architecture, security posture, NativeWind UI, and Expo Router. Designed so AI coding agents (Cursor, Claude Code) can confidently extend the codebase.
- **Audience:** Developers shipping mobile apps with AI assistance.
- **Pricing:** Paid, one-time per template ($49–$149).
- **Tech:** React Native, Expo SDK 54, TypeScript, NativeWind, Expo Router, Supabase, TanStack Query.

### [RapidNative](https://rapidnative.com/) → Prototyping / 原型设计
- **What:** AI-native mobile app builder. Describe or sketch your app, watch it build in real time, then ship to App Store / Play Store. Generates production-ready React Native code.
- **Audience:** Founders, PMs, designers, freelancers.
- **Pricing:** Freemium (20 free credits).

Both fill gaps in the current list — there are no React Native templates in Templates, and no AI-native mobile builder in Prototyping (which currently has v0, Webflow, etc. but they're web-only).

Thanks for maintaining this list!