### PR TITLE
Add AI假落地体检 to 产品发布推广 section

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@
 - [ASO 与 App 冷启动](https://github.com/Gingiris/gingiris-aso-growth): 应用商店优化、UGC 运营、多平台内容策略、AI 矩阵号的完整实操手册。
 
 
+- [AI假落地体检](https://github.com/ruiflow-team/ai-fake-landing-checkup): 免费开源的AI项目真假落地诊断清单，帮助独立开发者和小团队判断AI项目是真落地还是"看起来很忙"。提供10项评分维度和免费自检问卷。
 
 ## 财务税务
 - [ReceiptClaimer](https://receiptclaimer.com.au): 专为澳洲独立开发者、自由职业者和房东设计的AI税务抵扣追踪与审计核对平台，提供免费的报税计算器和收据管理工具。


### PR DESCRIPTION
## 新增条目

在「产品发布推广」章节末尾新增：

- [AI假落地体检](https://github.com/ruiflow-team/ai-fake-landing-checkup)：免费开源的AI项目真假落地诊断清单，帮助独立开发者和小团队判断AI项目是真落地还是看起来很忙。提供10项评分维度和免费自检问卷。

### 适合收录的理由
- 免费开源（MIT License）
- 专门为独立开发者和小团队设计
- 提供 10 项评分维度（业务流程、数据边界、隐私、维护等）
- 包含免费自检问卷和样本报告