### PR TITLE
Add AISO Tools to SEO section

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,5 +311,6 @@
 - [DNS Propagation Checker](https://dns-propagation-checker.autocompany.workers.dev): 开源DNS传播检查工具，全球多节点查询DNS记录传播状态。完全免费。
 - [PageGuard](https://pageguard.org): 免费网站健康扫描工具，一键检测SEO、性能、无障碍性和最佳实践，提供AI分析报告和REST API，无需注册。
 - [WebCoreLab](https://webcorelab.com) — AI-powered 272-check SEO audit + GEO/AEO optimization for indie hackers. Free audit tier available.
+- [AISO Tools](https://aisotools.com) — Directory and blog focused on AI Search Optimization (AISO/GEO): find and get discovered by ChatGPT, Perplexity, and other AI search tools. Free to browse and submit.
 
 


### PR DESCRIPTION
AISO Tools (aisotools.com) is a directory + blog for AI Search Optimization (AISO/GEO) — helping tools get found and recommended by ChatGPT, Perplexity, and other AI search engines. Fits alongside the other SEO tools in this section, free to browse/submit.