### PR TITLE
Add Traditional Chinese freelancer pricing toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@
 
 ## 模板
 - [Indie Hacker Toolkit](https://github.com/Wittlesus/indie-hacker-toolkit): 为独立开发者提供的5个实用规划模板，包括产品发布清单、定价计算器、竞争对手分析、用户画像和指标仪表板。付费产品，$19。
+- [接案報價與收款工具包](https://payment-flow-studio-tw.masstech.chatgpt.site/templates/freelancer-proposal-pricing-kit?source=github_awesome_indie_hacker_tools_e20): 給繁中個人接案者的 Excel 報價計算器與 Word 固定範圍提案範本，涵蓋訂金、變更核准、驗收與實收追蹤。付費產品，$19。
 - [Makerkit](https://makerkit.dev/): 提供多种基于Next.js的响应式模板，适用于各种应用场景。
 - [Shipfast](https://shipfa.st/): 提供多种基于Tailwind CSS的响应式模板，适用于各种应用场景。
 - [Supastarter](https://supastarter.com/): 提供多种基于Next.js的响应式模板，适用于各种应用场景。


### PR DESCRIPTION
## What this adds

One Traditional Chinese paid template kit for solo freelancers in the existing `模板` section. It contains an Excel pricing calculator and Word fixed-scope proposal template covering deposits, change approval, acceptance, and received-payment tracking.

## Disclosure

- I am the owner and seller of this closed-source US$19 product.
- This is a self-submission. It is not open source and it is not a free resource.
- The destination is the product's first-party Sites page. The `source=github_awesome_indie_hacker_tools_e20` query is only a first-party attribution label.
- There is no affiliate relationship and no direct Gumroad URL in this PR.
- A separate free fictional proof repository is publicly available at https://github.com/ja9740913/freelancer-fixed-scope-pricing-case-zh, but this PR adds only the paid product row and no second README link.
- The kit differs from the existing generic Indie Hacker Toolkit: it is specifically for Traditional Chinese freelance quoting, scope control, deposits, acceptance, and payment follow-up.
- I make no customer, revenue, ranking, conversion, legal, accounting, tax, or outcome claim.

The patch changes only `README.md`, adds one line, and removes nothing.