### PR TITLE
Add CD Calculator to Finance & Tax section

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@
 
 ## 财务税务
 - [ReceiptClaimer](https://receiptclaimer.com.au): 专为澳洲独立开发者、自由职业者和房东设计的AI税务抵扣追踪与审计核对平台，提供免费的报税计算器和收据管理工具。
+- [CD Calculator](https://nutilz.com/cd-calculator): 免费的定期存款(CD)收益计算器，帮助独立开发者对比CD梯投资与储蓄账户的收益差异，无需注册即可使用。
 
 ## 统计分析
 - [Posthog](https://posthog.com/): 开源的产品分析平台，提供用户行为跟踪、漏斗分析和特性标记等功能。有免费和付费计划。


### PR DESCRIPTION
Adds nutilz.com/cd-calculator (free CD laddering vs. savings account calculator, no signup) to the 财务税务 (Finance & Tax) section, alongside ReceiptClaimer.